### PR TITLE
Don't require PyZMQ unless using it

### DIFF
--- a/memory_watcher.py
+++ b/memory_watcher.py
@@ -1,7 +1,7 @@
 import binascii
-import zmq
 import util
 import os
+import sys
 import socket
 
 def parseMessage(message):
@@ -16,6 +16,12 @@ def parseMessage(message):
 
 class MemoryWatcherZMQ:
   def __init__(self, path):
+    try:
+      import zmq
+    except ImportError as err:
+      print("ImportError: {0}".format(err))
+      sys.exit("Either install pyzmq or run with the --nozmq option")
+
     context = zmq.Context()
 
     self.socket = context.socket(zmq.REP)


### PR DESCRIPTION
Minor change.  Since `zmq` is only useful when working with the custom dolphin build, it shouldn't be a hard requirement of using the run script. 
